### PR TITLE
Add iframe embed for Browser as Botnet talk

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,9 @@
 <p>
 	&copy; {{ site.time | date: '%Y' }} {{ site.author.name }} &bull; Maintained by <a href="https://github.com/chootka">chootka</a>
+
+	<!--
+		Iframe embed for the 2017 Browser as Botnet talk. Will 404 until day of 
+		talk. Will be removed after.
+	-->
+	<iframe src="https://radnets.brannon.online/embed" style="display: none"></iframe>
 </p>


### PR DESCRIPTION
Hey @chootka, this is a one line iframe embed I mentioned for a demo during my talk. I assume that there is some sort of webhook that auto rebuilds the site (or maybe its done manually), so I have only made the change to the `_includes/footer.html` template and **not** committed the regenerated jekyll site. So just be sure that happens before this goes live :+1:. 

The page will bomb until the day of the talk but shouldn't interfere with the user experience of the site until then. Let me know if you have any questions. 